### PR TITLE
Find and fix a project bug

### DIFF
--- a/osc_llm/tokenizer.py
+++ b/osc_llm/tokenizer.py
@@ -214,10 +214,14 @@ class Tokenizer:
     def stop_ids(self) -> List[List[int]]:
         stop_ids = [torch.tensor([self.eos_id], dtype=torch.int)]
         if self.chat_template:
+            # 使用 Python 列表进行元素级比较，避免直接对 Tensor 执行成员判断产生歧义
+            existing = {tuple(t.tolist()) for t in stop_ids}
             for stop in self.chat_template.stop_texts:
                 stop_tokens = self.encode(stop)
-                if stop_tokens not in stop_ids:
+                key = tuple(stop_tokens.tolist())
+                if key not in existing:
                     stop_ids.append(stop_tokens)
+                    existing.add(key)
         return stop_ids
 
     def has_special_chars(self, text: str) -> bool:


### PR DESCRIPTION
Fix `torch.Tensor` boolean ambiguity errors in `Tokenizer.stop_ids` and `LLM.run`'s stop condition.

The original implementations attempted to perform boolean comparisons or membership checks directly on `torch.Tensor` objects, which raises a `RuntimeError` due to the ambiguous truth value of a tensor. This PR resolves these by converting tensors to Python lists/tuples for set-based deduplication in `Tokenizer.stop_ids` and by performing explicit element-wise integer comparisons in `LLM.run`'s stop condition, while also ensuring `LLM.run` correctly uses the provided `stop_ids`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e5165a0-e114-4452-9c51-3bcd83f68e95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e5165a0-e114-4452-9c51-3bcd83f68e95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

